### PR TITLE
[chore]: bump golangci to support go 1.25

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,6 +23,6 @@ jobs:
           cache: true
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: 'v2.1'
+          version: 'v2.6'


### PR DESCRIPTION
this is a preparation to bump golang to 1.25. old golangci doesn't support go 1.25