### PR TITLE
goreleaser: ignore windows/arm build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
+      - goos: windows
+        goarch: arm
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - formats:


### PR DESCRIPTION
this fixes the

```
  ⨯ release failed after 9m32s                      
    error=
    │ build failed: exit status 2: go: unsupported GOOS/GOARCH pair windows/arm
    target=windows_arm_6
```