### PR TITLE
Add Archer service and endpoint fields

### DIFF
--- a/docs/data-sources/endpoint_service_v1.md
+++ b/docs/data-sources/endpoint_service_v1.md
@@ -40,6 +40,8 @@ The following arguments are supported:
 
 * `description` - (Optional) A description of the endpoint service.
 
+* `protocol` - (Optional) Filter services by their protocol (`HTTP` or `TCP`).
+
 * `ip_addresses` - (Optional) A list of IP addresses associated with the service.
 
 * `port` - (Optional) The port on which the service is exposed. Deprecated in
@@ -57,6 +59,9 @@ The following arguments are supported:
 
 * `require_approval` - (Optional) Filter services by whether they require approval.
 
+* `snat_pool_size` - (Optional) Filter services by the number of allocated SNAT
+  IP addresses.
+
 * `visibility` - (Optional) Filter services by their visibility (`private` or `public`).
 
 * `tags` - (Optional) A list of tags assigned to the service.
@@ -71,5 +76,6 @@ In addition to all arguments above, the following attributes are exported:
 * `all_tags` - A list of all tags assigned to the service.
 * `host` - The host of the service owner.
 * `status` - The current status of the service.
+* `health_status` - The current backend health status of the service.
 * `created_at` - The timestamp when the service was created.
 * `updated_at` - The timestamp when the service was last updated.

--- a/docs/resources/endpoint_service_v1.md
+++ b/docs/resources/endpoint_service_v1.md
@@ -17,9 +17,11 @@ SAP Cloud Infrastructure environment.
 resource "sci_endpoint_service_v1" "service_1" {
   availability_zone = "region1a"
   name              = "service1"
+  protocol          = "TCP"
   ip_addresses      = ["192.168.1.1"]
   ports             = [8080]
   network_id        = "982d8699-b1a0-4933-8b65-7f1cd8a0f78b"
+  snat_pool_size    = 2
   visibility        = "private"
   tags              = ["tag1", "tag2"]
 }
@@ -42,6 +44,9 @@ The following arguments are supported:
 * `name` - (Optional) The name of the endpoint service.
 
 * `description` - (Optional) A description of the endpoint service.
+
+* `protocol` - (Optional) The protocol of the endpoint service (`HTTP` or
+  `TCP`).
 
 * `ip_addresses` - (Required) A list of IP addresses associated with the
   service.
@@ -67,6 +72,9 @@ The following arguments are supported:
 * `require_approval` - (Optional) Specifies if the service requires approval.
   Defaults to `true`.
 
+* `snat_pool_size` - (Optional) The number of SNAT IP addresses allocated for
+  the service. Must be between `1` and `8`.
+
 * `visibility` - (Optional) The visibility of the service (`private` or
   `public`). Defaults to `private`.
 
@@ -79,6 +87,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the endpoint service.
 * `host` - The host name of the service.
 * `status` - The current status of the service.
+* `health_status` - The current backend health status of the service.
 * `created_at` - The timestamp when the service was created.
 * `updated_at` - The timestamp when the service was last updated.
 

--- a/docs/resources/endpoint_v1.md
+++ b/docs/resources/endpoint_v1.md
@@ -23,9 +23,10 @@ data "sci_endpoint_service_v1" "service_1" {
 }
 
 resource "sci_endpoint_v1" "endpoint_1" {
-  name        = "endpoint_1"
-  service_id  = data.sci_endpoint_service_v1.service_1.id
-  tags        = ["tag1", "tag2"]
+  name                 = "endpoint_1"
+  service_id           = data.sci_endpoint_service_v1.service_1.id
+  connection_mirroring = true
+  tags                 = ["tag1", "tag2"]
 
   target {
     network = "49b6480b-24d3-4376-a4c9-aecbb89e16d9"
@@ -42,6 +43,10 @@ resource "sci_endpoint_v1" "endpoint_1" {
 * `name` - (Optional) The name of the endpoint.
 
 * `description` - (Optional) A description of the endpoint.
+
+* `connection_mirroring` - (Optional) Enables BIG-IP connection mirroring for
+  high availability failover. This currently only affects endpoints for
+  services with provider type `tenant`.
 
 * `project_id` - (Optional) The ID of the project in which to create the
   endpoint. Changing this forces a new resource to be created.
@@ -70,6 +75,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the endpoint.
 * `ip_address` - The IP address assigned to the endpoint.
+* `connection_mirroring` - Whether connection mirroring is enabled for the
+  endpoint.
 * `status` - The current status of the endpoint.
 * `created_at` - The timestamp when the endpoint was created.
 * `updated_at` - The timestamp when the endpoint was last updated.

--- a/sci/data_source_sci_endpoint_service_v1.go
+++ b/sci/data_source_sci_endpoint_service_v1.go
@@ -41,6 +41,14 @@ func dataSourceSCIEndpointServiceV1() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"protocol": {
+				Type: schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{
+					"HTTP", "TCP",
+				}, false),
+				Optional: true,
+				Computed: true,
+			},
 			"ip_addresses": {
 				Type: schema.TypeList,
 				Elem: &schema.Schema{
@@ -103,6 +111,12 @@ func dataSourceSCIEndpointServiceV1() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"snat_pool_size": {
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntBetween(1, 8),
+				Optional:     true,
+				Computed:     true,
+			},
 			"visibility": {
 				Type: schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{
@@ -134,6 +148,10 @@ func dataSourceSCIEndpointServiceV1() *schema.Resource {
 			"status": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
+			},
+			"health_status": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"created_at": {
@@ -177,8 +195,9 @@ func dataSourceSCIEndpointServiceV1Read(ctx context.Context, d *schema.ResourceD
 	filteredServices := make([]models.Service, 0, len(services.Payload.Items))
 
 	// define filter values
-	var name, description, availabilityZone, networkID, provider, visibility, host, status *string
+	var name, description, availabilityZone, networkID, provider, protocol, visibility, host, status *string
 	var enabled, proxyProtocol, requireApproval *bool
+	var snatPoolSize *int32
 	var ports []int32
 	var ipAddresses []string
 
@@ -197,6 +216,9 @@ func dataSourceSCIEndpointServiceV1Read(ctx context.Context, d *schema.ResourceD
 	if v, ok := d.GetOk("service_provider"); ok {
 		provider = ptr(v.(string))
 	}
+	if v, ok := d.GetOk("protocol"); ok {
+		protocol = ptr(v.(string))
+	}
 	if v, ok := d.GetOk("visibility"); ok {
 		visibility = ptr(v.(string))
 	}
@@ -206,7 +228,6 @@ func dataSourceSCIEndpointServiceV1Read(ctx context.Context, d *schema.ResourceD
 	if v, ok := d.GetOk("status"); ok {
 		status = ptr(v.(string))
 	}
-
 	if v, ok := d.GetOk("enabled"); ok {
 		enabled = ptr(v.(bool))
 	}
@@ -215,6 +236,10 @@ func dataSourceSCIEndpointServiceV1Read(ctx context.Context, d *schema.ResourceD
 	}
 	if v, ok := d.GetOk("require_approval"); ok {
 		requireApproval = ptr(v.(bool))
+	}
+	if v, ok := d.GetOk("snat_pool_size"); ok {
+		v := int32(v.(int))
+		snatPoolSize = &v
 	}
 
 	if v, ok := getOkExists(d, "port"); ok {
@@ -248,6 +273,9 @@ func dataSourceSCIEndpointServiceV1Read(ctx context.Context, d *schema.ResourceD
 		if provider != nil && *provider != ptrValue(svc.Provider) {
 			continue
 		}
+		if protocol != nil && *protocol != ptrValue(svc.Protocol) {
+			continue
+		}
 		if visibility != nil && *visibility != ptrValue(svc.Visibility) {
 			continue
 		}
@@ -258,6 +286,9 @@ func dataSourceSCIEndpointServiceV1Read(ctx context.Context, d *schema.ResourceD
 			continue
 		}
 		if requireApproval != nil && *requireApproval != ptrValue(svc.RequireApproval) {
+			continue
+		}
+		if snatPoolSize != nil && *snatPoolSize != ptrValue(svc.SnatPoolSize) {
 			continue
 		}
 		if len(ports) > 0 && !isSubset(ports, svc.Ports) {
@@ -296,13 +327,16 @@ func dataSourceSCIEndpointServiceV1Read(ctx context.Context, d *schema.ResourceD
 	_ = d.Set("project_id", svc.ProjectID)
 	_ = d.Set("all_tags", svc.Tags)
 	_ = d.Set("service_provider", ptrValue(svc.Provider))
+	_ = d.Set("protocol", ptrValue(svc.Protocol))
 	_ = d.Set("proxy_protocol", ptrValue(svc.ProxyProtocol))
 	_ = d.Set("require_approval", ptrValue(svc.RequireApproval))
+	_ = d.Set("snat_pool_size", ptrValue(svc.SnatPoolSize))
 	_ = d.Set("visibility", ptrValue(svc.Visibility))
 
 	// computed
 	_ = d.Set("host", ptrValue(svc.Host))
 	_ = d.Set("status", string(svc.Status))
+	_ = d.Set("health_status", ptrValue(svc.HealthStatus))
 	_ = d.Set("created_at", svc.CreatedAt.String())
 	_ = d.Set("updated_at", svc.UpdatedAt.String())
 

--- a/sci/resource_sci_endpoint_service_v1.go
+++ b/sci/resource_sci_endpoint_service_v1.go
@@ -50,6 +50,14 @@ func resourceSCIEndpointServiceV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"protocol": {
+				Type: schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{
+					"HTTP", "TCP",
+				}, false),
+				Optional: true,
+				Computed: true,
+			},
 			"ip_addresses": {
 				Type: schema.TypeList,
 				Elem: &schema.Schema{
@@ -106,6 +114,12 @@ func resourceSCIEndpointServiceV1() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"snat_pool_size": {
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntBetween(1, 8),
+				Optional:     true,
+				Computed:     true,
+			},
 			"visibility": {
 				Type: schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{
@@ -127,6 +141,10 @@ func resourceSCIEndpointServiceV1() *schema.Resource {
 				Computed: true,
 			},
 			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"health_status": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -173,11 +191,17 @@ func resourceSCIEndpointServiceV1Create(ctx context.Context, d *schema.ResourceD
 	if v, ok := getOkExists(d, "require_approval"); ok {
 		svc.RequireApproval = ptr(v.(bool))
 	}
+	if v, ok := getOkExists(d, "snat_pool_size"); ok {
+		svc.SnatPoolSize = ptr(int32(v.(int)))
+	}
 	if v, ok := d.GetOk("availability_zone"); ok && v != "" {
 		svc.AvailabilityZone = ptr(v.(string))
 	}
-	if v, ok := d.GetOk("svc_provider"); ok && v != "" {
+	if v, ok := d.GetOk("service_provider"); ok && v != "" {
 		svc.Provider = ptr(v.(string))
+	}
+	if v, ok := d.GetOk("protocol"); ok && v != "" {
+		svc.Protocol = ptr(v.(string))
 	}
 	if v, ok := d.GetOk("visibility"); ok && v != "" {
 		svc.Visibility = ptr(v.(string))
@@ -283,6 +307,14 @@ func resourceSCIEndpointServiceV1Update(ctx context.Context, d *schema.ResourceD
 	if d.HasChange("require_approval") {
 		v := d.Get("require_approval").(bool)
 		svc.RequireApproval = &v
+	}
+	if d.HasChange("protocol") {
+		v := d.Get("protocol").(string)
+		svc.Protocol = &v
+	}
+	if d.HasChange("snat_pool_size") {
+		v := int32(d.Get("snat_pool_size").(int))
+		svc.SnatPoolSize = &v
 	}
 	if d.HasChange("visibility") {
 		v := d.Get("visibility").(string)
@@ -411,13 +443,16 @@ func archerSetServiceResource(d *schema.ResourceData, config *Config, svc *model
 	_ = d.Set("project_id", svc.ProjectID)
 	_ = d.Set("tags", svc.Tags)
 	_ = d.Set("service_provider", ptrValue(svc.Provider))
+	_ = d.Set("protocol", ptrValue(svc.Protocol))
 	_ = d.Set("proxy_protocol", ptrValue(svc.ProxyProtocol))
 	_ = d.Set("require_approval", ptrValue(svc.RequireApproval))
+	_ = d.Set("snat_pool_size", ptrValue(svc.SnatPoolSize))
 	_ = d.Set("visibility", ptrValue(svc.Visibility))
 
 	// computed
 	_ = d.Set("host", ptrValue(svc.Host))
 	_ = d.Set("status", string(svc.Status))
+	_ = d.Set("health_status", ptrValue(svc.HealthStatus))
 	_ = d.Set("created_at", svc.CreatedAt.String())
 	_ = d.Set("updated_at", svc.UpdatedAt.String())
 

--- a/sci/resource_sci_endpoint_v1.go
+++ b/sci/resource_sci_endpoint_v1.go
@@ -39,6 +39,11 @@ func resourceSCIEndpointV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"connection_mirroring": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -122,6 +127,9 @@ func resourceSCIEndpointV1Create(ctx context.Context, d *schema.ResourceData, me
 		Tags:        expandToStringSlice(d.Get("tags").([]any)),
 		Target:      flattenEndpointTarget(d.Get("target").([]any)),
 	}
+	if v, ok := getOkExists(d, "connection_mirroring"); ok {
+		ept.ConnectionMirroring = new(v.(bool))
+	}
 
 	opts := &endpoint.PostEndpointParams{
 		Body:    ept,
@@ -195,6 +203,9 @@ func resourceSCIEndpointV1Update(ctx context.Context, d *schema.ResourceData, me
 	}
 	if d.HasChange("description") {
 		ept.Description = ptr(d.Get("description").(string))
+	}
+	if d.HasChange("connection_mirroring") {
+		ept.ConnectionMirroring = new(d.Get("connection_mirroring").(bool))
 	}
 	if d.HasChange("tags") {
 		ept.Tags = expandToStringSlice(d.Get("tags").([]any))
@@ -306,6 +317,7 @@ func archerSetEndpointResource(d *schema.ResourceData, config *Config, ept *mode
 	_ = d.Set("description", ept.Description)
 	_ = d.Set("service_id", ept.ServiceID)
 	_ = d.Set("project_id", ept.ProjectID)
+	_ = d.Set("connection_mirroring", ptrValue(ept.ConnectionMirroring))
 	_ = d.Set("ip_address", ept.IPAddress)
 	_ = d.Set("tags", ept.Tags)
 	_ = d.Set("target", expandEndpointTarget(ept.Target))


### PR DESCRIPTION
Expose additional Archer service fields in Terraform, including protocol, snat_pool_size, and health_status, and fix the service_provider create mapping.

Also expose endpoint connection_mirroring and update the endpoint and endpoint service documentation accordingly.